### PR TITLE
implement remember me functionality in authentication system

### DIFF
--- a/src/main/java/hcmute/lp/backend/controller/AuthController.java
+++ b/src/main/java/hcmute/lp/backend/controller/AuthController.java
@@ -11,14 +11,12 @@ import lombok.RequiredArgsConstructor;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@CrossOrigin(origins = "http://localhost:4200")
 @Tag(name = "Auth API")
 public class AuthController {
     private final AuthService authService;

--- a/src/main/java/hcmute/lp/backend/controller/UserController.java
+++ b/src/main/java/hcmute/lp/backend/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
     }
 
     @PostMapping
-//    @HasAnyRole({"ADMIN"})
+    @HasAnyRole({"ADMIN"})
     public ResponseEntity<ApiResponse> createUser(@Valid @RequestBody UserRequest userRequest) {
         UserDto createdUser = userService.createUser(userRequest);
         return new ResponseEntity<>(new ApiResponse(true, "Tạo người dùng thành công", createdUser), HttpStatus.CREATED);

--- a/src/main/java/hcmute/lp/backend/model/dto/auth/LoginRequest.java
+++ b/src/main/java/hcmute/lp/backend/model/dto/auth/LoginRequest.java
@@ -18,4 +18,6 @@ public class LoginRequest {
 
     @NotBlank(message = "Mật khẩu không được để trống")
     private String password;
+
+    private Boolean rememberMe;
 }

--- a/src/main/java/hcmute/lp/backend/security/JwtService.java
+++ b/src/main/java/hcmute/lp/backend/security/JwtService.java
@@ -24,8 +24,14 @@ public class JwtService {
     @Value("${application.security.jwt.expiration}")
     private long jwtExpiration;
 
+    @Value("${application.security.jwt.long-lived-expiration:2592000000}") // Mặc định 30 ngày
+    private long jwtLongLivedExpiration;
+
     @Value("${application.security.jwt.refresh-token.expiration}")
     private long refreshExpiration;
+
+    @Value("${application.security.jwt.refresh-token.long-lived-expiration:7776000000}") // Mặc định 90 ngày
+    private long refreshLongLivedExpiration;
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);
@@ -37,18 +43,29 @@ public class JwtService {
     }
 
     public String generateToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails);
+        return generateToken(userDetails, false);
+    }
+
+    public String generateToken(UserDetails userDetails, boolean rememberMe) {
+        return generateToken(new HashMap<>(), userDetails, rememberMe);
     }
 
     public String generateToken(
             Map<String, Object> extraClaims,
-            UserDetails userDetails
+            UserDetails userDetails,
+            boolean rememberMe
     ) {
-        return buildToken(extraClaims, userDetails, jwtExpiration);
+        long expiration = rememberMe ? jwtLongLivedExpiration : jwtExpiration;
+        return buildToken(extraClaims, userDetails, expiration);
     }
 
     public String generateRefreshToken(UserDetails userDetails) {
-        return buildToken(new HashMap<>(), userDetails, refreshExpiration);
+        return generateRefreshToken(userDetails, false);
+    }
+
+    public String generateRefreshToken(UserDetails userDetails, boolean rememberMe) {
+        long expiration = rememberMe ? refreshLongLivedExpiration : refreshExpiration;
+        return buildToken(new HashMap<>(), userDetails, expiration);
     }
 
     private String buildToken(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,3 +26,9 @@ springdoc.swagger-ui.filter=true
 application.security.jwt.secret-key=111110000111111000000000000000000000000000000000
 application.security.jwt.expiration=86400000
 application.security.jwt.refresh-token.expiration=604800000
+
+# Th?i h?n cho token dài h?n (remember me) - 30 ngày
+application.security.jwt.long-lived-expiration=2592000000
+
+# Th?i h?n cho refresh token dài h?n (remember me) - 90 ngày
+application.security.jwt.refresh-token.long-lived-expiration=7776000000


### PR DESCRIPTION
- Add rememberMe field to LoginRequest
- Update JwtService to generate tokens with different expiration times
- Modify AuthService to handle rememberMe flag
- Configure long-lived token expiration times
- Add proper error handling and logging

## Summary by Sourcery

Implement remember me functionality in the authentication system to allow users to stay logged in for an extended period

New Features:
- Add remember me option to login process with configurable long-lived token expiration

Enhancements:
- Extend JWT service to support different token expiration times
- Update authentication flow to handle remember me flag

Chores:
- Update application properties to include long-lived token configurations
- Add cross-origin support to authentication controller