### PR TITLE
add sample pageable for brand and cate

### DIFF
--- a/src/main/java/hcmute/lp/backend/controller/BrandController.java
+++ b/src/main/java/hcmute/lp/backend/controller/BrandController.java
@@ -7,6 +7,7 @@ import hcmute.lp.backend.service.BrandService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -79,4 +80,15 @@ public class BrandController {
         return ResponseEntity.ok(statistics);
     }
 
+    @GetMapping("/pagination")
+    public ResponseEntity<ApiResponse<Page<BrandDto>>> getBrandsPaginated(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "name") String sortBy,
+            @RequestParam(defaultValue = "asc") String sortDirection,
+            @RequestParam(required = false) String status) {
+        Page<BrandDto> brandPage = brandService.getBrandsPaginated(
+                page, size, sortBy, sortDirection, status);
+        return ResponseEntity.ok(ApiResponse.success("Brands retrieved successfully", brandPage));
+    }
 }

--- a/src/main/java/hcmute/lp/backend/controller/CategoryController.java
+++ b/src/main/java/hcmute/lp/backend/controller/CategoryController.java
@@ -7,6 +7,7 @@ import hcmute.lp.backend.service.CategoryService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -64,5 +65,17 @@ public class CategoryController {
         String status = statusRequest.get("status");
         CategoryDto updatedCategory = categoryService.updateCategoryStatus(id, status);
         return ResponseEntity.ok(updatedCategory);
+    }
+
+    @GetMapping("/pagination")
+    public ResponseEntity<ApiResponse<Page<CategoryDto>>> getCategoriesPaginated(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "name") String sortBy,
+            @RequestParam(defaultValue = "asc") String sortDirection,
+            @RequestParam(required = false) String status) {
+        Page<CategoryDto> categoryPage = categoryService.getCategoriesPaginated(
+                page, size, sortBy, sortDirection, status);
+        return ResponseEntity.ok(ApiResponse.success("Categories retrieved successfully", categoryPage));
     }
 }

--- a/src/main/java/hcmute/lp/backend/repository/BrandRepository.java
+++ b/src/main/java/hcmute/lp/backend/repository/BrandRepository.java
@@ -1,6 +1,8 @@
 package hcmute.lp.backend.repository;
 
 import hcmute.lp.backend.model.entity.Brand;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,4 +17,6 @@ public interface BrandRepository extends JpaRepository<Brand, Integer> {
     List<Brand> findByStatus(Brand.BrandStatus status);
 
     List<Brand> findByStatusOrderByProductsDesc(Brand.BrandStatus status);
+
+    Page<Brand> findByStatus(Brand.BrandStatus status, Pageable pageable);
 }

--- a/src/main/java/hcmute/lp/backend/repository/CategoryRepository.java
+++ b/src/main/java/hcmute/lp/backend/repository/CategoryRepository.java
@@ -1,6 +1,8 @@
 package hcmute.lp.backend.repository;
 
 import hcmute.lp.backend.model.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -21,4 +23,5 @@ public interface CategoryRepository extends JpaRepository<Category, Integer> {
 
     List<Category> findByStatus(String status);
 
+    Page<Category> findByStatus(Category.CategoryStatus status, Pageable pageable);
 }

--- a/src/main/java/hcmute/lp/backend/service/BrandService.java
+++ b/src/main/java/hcmute/lp/backend/service/BrandService.java
@@ -3,6 +3,7 @@ package hcmute.lp.backend.service;
 import hcmute.lp.backend.model.dto.brand.BrandDto;
 import hcmute.lp.backend.model.dto.brand.BrandRequest;
 import hcmute.lp.backend.model.entity.Brand;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Map;
@@ -20,4 +21,6 @@ public interface BrandService {
     List<BrandDto> getFeaturedBrands(int limit);
 
     Map<String, Integer> getBrandStatistics();
+
+    Page<BrandDto> getBrandsPaginated(int page, int size, String sortBy, String sortDirection, String status);
 }

--- a/src/main/java/hcmute/lp/backend/service/CategoryService.java
+++ b/src/main/java/hcmute/lp/backend/service/CategoryService.java
@@ -2,6 +2,7 @@ package hcmute.lp.backend.service;
 
 import hcmute.lp.backend.model.dto.category.CategoryDto;
 import hcmute.lp.backend.model.dto.category.CategoryRequest;
+import org.springframework.data.domain.Page;
 
 
 import java.util.List;
@@ -20,4 +21,5 @@ public interface CategoryService {
     List<CategoryDto> getCategoriesByStatus(String status);
     List<CategoryDto> getCategoriesByParentIdAndStatus(int parentId, String status);
 
+    Page<CategoryDto> getCategoriesPaginated(int page, int size, String sortBy, String sortDirection, String status);
 }


### PR DESCRIPTION
## Summary by Sourcery

Add pagination support for brands and categories with flexible filtering and sorting

New Features:
- Implement paginated retrieval of brands and categories with support for sorting, page size, and optional status filtering

Enhancements:
- Extend repository and service layers to support paginated queries
- Add new endpoint for paginated brand and category retrieval